### PR TITLE
Fix for reddit companion

### DIFF
--- a/boxed_base.css
+++ b/boxed_base.css
@@ -1,4 +1,4 @@
-/* == Boxed reddit CSS Theme v1.1.3 - (http://www.reddit.com/r/boxed/)== */
+/* == Boxed reddit CSS Theme v1.1.4 - (http://www.reddit.com/r/boxed/)== */
 
 /* General markup */
 body {
@@ -940,5 +940,7 @@ a[href$="#spoiler"][title]::before {
 	border-color: #C1BFBF;
 }
 
+/* reddit companion + sticky announcements fix */
+html { position: relative; }
 
 /* ==Boxed reddit CSS Theme v1.1.3 - (http://www.reddit.com/r/boxed/)== */


### PR DESCRIPTION
The official reddit extension for Chrome inserts a top margin of 30px to
the HTML element. Any element that has been absolutely positioned, eg
sticky announcement/submit buttons, that only has statically positioned
parents, will be 30px further up the page than intended.
